### PR TITLE
fix: Quote identifiers in column grant/revoke statements

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -285,6 +285,14 @@ func setToPgIdentList(schema string, idents *schema.Set) string {
 	return strings.Join(quotedIdents, ",")
 }
 
+func setToPgIdentListWithoutSchema(idents *schema.Set) string {
+	quotedIdents := make([]string, idents.Len())
+	for i, ident := range idents.List() {
+		quotedIdents[i] = pq.QuoteIdentifier(ident.(string))
+	}
+	return strings.Join(quotedIdents, ",")
+}
+
 func setToPgIdentSimpleList(idents *schema.Set) string {
 	quotedIdents := make([]string, idents.Len())
 	for i, ident := range idents.List() {

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -540,14 +540,10 @@ func createGrantQuery(d *schema.ResourceData, privileges []string) string {
 		)
 	case "COLUMN":
 		objects := d.Get("objects").(*schema.Set)
-		columns := []string{}
-		for _, col := range d.Get("columns").(*schema.Set).List() {
-			columns = append(columns, col.(string))
-		}
 		query = fmt.Sprintf(
 			"GRANT %s (%s) ON TABLE %s TO %s",
 			strings.Join(privileges, ","),
-			strings.Join(columns, ","),
+			setToPgIdentListWithoutSchema(d.Get("columns").(*schema.Set)),
 			setToPgIdentList(d.Get("schema").(string), objects),
 			pq.QuoteIdentifier(d.Get("role").(string)),
 		)
@@ -620,7 +616,7 @@ func createRevokeQuery(d *schema.ResourceData) string {
 			query = fmt.Sprintf(
 				"REVOKE %s (%s) ON TABLE %s FROM %s",
 				setToPgIdentSimpleList(privileges),
-				setToPgIdentSimpleList(columns),
+				setToPgIdentListWithoutSchema(columns),
 				setToPgIdentList(d.Get("schema").(string), objects),
 				pq.QuoteIdentifier(d.Get("role").(string)),
 			)

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -125,7 +125,7 @@ func TestCreateGrantQuery(t *testing.T) {
 				"role":        roleName,
 			}),
 			privileges: []string{"SELECT"},
-			expected:   fmt.Sprintf(`GRANT SELECT (col2,col1) ON TABLE %[1]s."o1" TO %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+			expected:   fmt.Sprintf(`GRANT SELECT (%[2]s,%[3]s) ON TABLE %[1]s."o1" TO %[4]s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier("col2"), pq.QuoteIdentifier("col1"), pq.QuoteIdentifier(roleName)),
 		},
 		{
 			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
@@ -270,7 +270,7 @@ func TestCreateRevokeQuery(t *testing.T) {
 				"role":        roleName,
 				"privileges":  []interface{}{"SELECT"},
 			}),
-			expected: fmt.Sprintf(`REVOKE SELECT (col2,col1) ON TABLE %[1]s."o1" FROM %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+			expected: fmt.Sprintf(`REVOKE SELECT ("col2","col1") ON TABLE %[1]s."o1" FROM %s`, pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
 		},
 		{
 			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{


### PR DESCRIPTION
Addresses failures when column names coincide with postgresql keywords