### PR TITLE
Use function arguments in grants

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Grants for functions now allow function signatures to be provided.
 * Merged from [upstream v1.18.0](https://github.com/cyrilgdn/terraform-provider-postgresql/commit/83f06753691b48f7caea7616e6fd443a085761a0)
 
 ## 1.19.0 (November 1, 2022)

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -555,3 +555,18 @@ func isUniqueArr(arr []interface{}) (interface{}, bool) {
 	}
 	return nil, true
 }
+
+func normalizeFunctionNames(objects *schema.Set) *schema.Set {
+	normalizedObjects := make([]interface{}, objects.Len())
+	for i, v := range objects.List() {
+		normalizedObjects[i] = normalizeFunctionName(v.(string))
+	}
+	return schema.NewSet(schema.HashString, normalizedObjects)
+}
+
+func normalizeFunctionName(name string) string {
+	if strings.Index(name, "(") == -1 {
+		return name + "()"
+	}
+	return name
+}

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -288,12 +288,21 @@ func pgArrayToSet(arr pq.ByteaArray) *schema.Set {
 	return schema.NewSet(schema.HashString, s)
 }
 
-func setToPgIdentList(schema string, idents *schema.Set) string {
+func setToPgIdentList(schema string, idents *schema.Set, quoteIdents ...bool) string {
+	// The quoteIndents variadic argument is used to pass an optional boolean value that defaults to true
+	useQuotes := true
+	if len(quoteIdents) > 0 {
+		useQuotes = quoteIdents[0]
+	}
 	quotedIdents := make([]string, idents.Len())
 	for i, ident := range idents.List() {
+		identifier := ident.(string)
+		if useQuotes {
+			identifier = pq.QuoteIdentifier(identifier)
+		}
 		quotedIdents[i] = fmt.Sprintf(
 			"%s.%s",
-			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(ident.(string)),
+			pq.QuoteIdentifier(schema), identifier,
 		)
 	}
 	return strings.Join(quotedIdents, ",")


### PR DESCRIPTION
Ultimately the change here is that function names as provided in terraform config are no longer quoted as identifiers, so you can express a grant for `func_name(text)` without it being misinterpreted as an invalid function name. This is necessary to support grants for overloaded function signatures.