### PR TITLE
Support column privileges for views

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Properly support column privileges for views (and materialized views, foreign tables, and partitioned tables)
 * Grants for functions now allow function signatures to be provided.
 * Merged from [upstream v1.18.0](https://github.com/cyrilgdn/terraform-provider-postgresql/commit/83f06753691b48f7caea7616e6fd443a085761a0)
 

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -231,20 +231,20 @@ func readRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	if pgSchema != "" {
 		query = `SELECT array_agg(prtype) FROM (
 		SELECT defaclnamespace, (aclexplode(defaclacl)).* FROM pg_default_acl
-		WHERE defaclobjtype = $3
+		WHERE defaclobjtype = ANY($3)
 	) AS t (namespace, grantor_oid, grantee_oid, prtype, grantable)
 	JOIN pg_namespace ON pg_namespace.oid = namespace
 	WHERE grantee_oid = $1 AND nspname = $2 AND pg_get_userbyid(grantor_oid) = $4;
 `
-		queryArgs = []interface{}{roleOID, pgSchema, objectTypes[objectType], owner}
+		queryArgs = []interface{}{roleOID, pgSchema, pq.Array(objectTypes[objectType]), owner}
 	} else {
 		query = `SELECT array_agg(prtype) FROM (
 		SELECT defaclnamespace, (aclexplode(defaclacl)).* FROM pg_default_acl
-		WHERE defaclobjtype = $2
+		WHERE defaclobjtype = ANY($2)
 	) AS t (namespace, grantor_oid, grantee_oid, prtype, grantable)
 	WHERE grantee_oid = $1 AND namespace = 0 AND pg_get_userbyid(grantor_oid) = $3;
 `
-		queryArgs = []interface{}{roleOID, objectTypes[objectType], owner}
+		queryArgs = []interface{}{roleOID, pq.Array(objectTypes[objectType]), owner}
 	}
 
 	// This query aggregates the list of default privileges type (prtype)


### PR DESCRIPTION
Incorporates the other `relkind` values for views, materialized views, foreign tables, and partitioned tables into filtering when querying privileges. This allows the plugin to appropriately read column privileges for views, fixing the permanent-diff issue.