### PR TITLE
Functions: allow replace on create

### DIFF
--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Allow replacing already existing functions on initial resource creation
+
 ## 1.20.0 (January 11, 2023)
 
 * Properly support column privileges for views (and materialized views, foreign tables, and partitioned tables)

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -17,6 +17,7 @@ const (
 	funcReturnsAttr     = "returns"
 	funcDropCascadeAttr = "drop_cascade"
 	funcDatabaseAttr    = "database"
+	funcReplaceAttr     = "replace"
 
 	funcArgTypeAttr    = "type"
 	funcArgNameAttr    = "name"
@@ -107,6 +108,12 @@ func resourcePostgreSQLFunction() *schema.Resource {
 				ForceNew:    true,
 				Description: "The database where the function is located. If not specified, the provider default database is used.",
 			},
+			funcReplaceAttr: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Replace the function if one already exists",
+			},
 		},
 	}
 }
@@ -118,8 +125,8 @@ func resourcePostgreSQLFunctionCreate(db *DBConnection, d *schema.ResourceData) 
 			db.version,
 		)
 	}
-
-	if err := createFunction(db, d, false); err != nil {
+	replace := d.Get(funcReplaceAttr).(bool)
+	if err := createFunction(db, d, replace); err != nil {
 		return err
 	}
 

--- a/postgresql/resource_postgresql_function_test.go
+++ b/postgresql/resource_postgresql_function_test.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -139,6 +140,54 @@ resource "postgresql_function" "increment" {
 					resource.TestCheckResourceAttr(
 						"postgresql_function.increment", "schema", "test"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlFunction_FailsCreateOnAlreadyExistingFunction(t *testing.T) {
+	skipIfNotAcc(t)
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	dbName, _ := getTestDBNames(dbSuffix)
+	config := fmt.Sprintf(`
+resource "postgresql_function" "basic_function" {
+    name = "basic_function"
+	database = "%s"
+	returns = "integer"
+    body = <<-EOF
+        AS $$
+        BEGIN
+            RETURN 1;
+        END;
+        $$ LANGUAGE plpgsql;
+    EOF
+}
+`, dbName)
+	existingFunctions := map[string]string{
+		"basic_function()": `
+RETURNS integer AS $$
+BEGIN
+	RETURN 42;
+END;
+$$ LANGUAGE plpgsql;
+`,
+	}
+
+	createTestFunctions(t, dbSuffix, existingFunctions, "")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureFunction)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("function \"[a-zA-Z_]+\" already exists with same argument types"),
 			},
 		},
 	})

--- a/website/docs/r/postgresql_function.html.markdown
+++ b/website/docs/r/postgresql_function.html.markdown
@@ -54,3 +54,6 @@ resource "postgresql_function" "increment" {
 
 * `drop_cascade` - (Optional) True to automatically drop objects that depend on the function (such as 
   operators or triggers), and in turn all objects that depend on those objects. Default is false.
+
+* `replace` - (Optional) Set true to replace any function that currently exists matching the same signature during 
+  resource creation. Default is false


### PR DESCRIPTION
Adds a new `replace` attribute to `postgresql_function` resources which makes the resource creation use `CREATE OR REPLACE FUNCTION ...` instead of just `CREATE FUNCTION`. 

This allows bringing already existing functions into terraform management in the cases where function replacement is acceptable.