### PR TITLE
Fix erroneous REVOKE ALL when new grants are created

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -269,12 +269,12 @@ func validatePrivileges(d *schema.ResourceData) error {
 
 // getDataForRevoke returns a value for a REVOKE statement from the given resource data key.
 //
-// If the key has changes, the "old" value, which incorporates both previous Terraform state and any drift detected
-// during the planning phase, will be returned.
+// If the resource is not new and the key has changes, the "old" value, which incorporates both previous Terraform state
+// and any drift detected during the planning phase, will be returned.
 //
-// If the key does not have changes, the current value is returned.
+// If the resource is new or the key does not have changes, the current value is returned.
 func getDataForRevoke(d *schema.ResourceData, key string) interface{} {
-	if d.HasChange(key) {
+	if !d.IsNewResource() && d.HasChange(key) {
 		oldValue, _ := d.GetChange(key)
 		return oldValue
 	}


### PR DESCRIPTION
The `getDataForRevoke` function had been created with the assumption that it was safe to just check for changes and always use the old version of changed fields to perform revokes. However, when a resource is new, the resource's `HasChanges` method will return true for all fields, and the "old" value will always be empty. This caused the calling resource code to fall into the default case of performing a `REVOKE ALL`, which is intended behavior for a resource that defines no objects or privileges.

The fix is to specifically check whether a resource is new, and if it is, only return the current field values, which will result in a noop (because the revoke will contain exactly what the following grant will).