### PR TITLE
Separate kinds from ACL types

### DIFF
--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -30,9 +30,6 @@ var allowedObjectTypes = []string{
 var objectTypes = map[string][]string{
 	"table":    {"r", "v", "m", "f", "p"},
 	"sequence": {"S"},
-	"function": {"f"},
-	"type":     {"T"},
-	"schema":   {"n"},
 }
 
 func resourcePostgreSQLGrant() *schema.Resource {


### PR DESCRIPTION
I realized when I was looking into supporting grants for types that the `objectTypes` map in `resource_postgresql_grant.go` was doing double-duty for both `kind` in `pg_class` and `defaclobjtype` in `pg_default_acl`. They're similar, but not the same, so they should be different variables.