### PR TITLE
Quote role parameter values by default, allow disabling

### DIFF
--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -219,6 +219,7 @@ resource "postgresql_role" "role_created_with_params" {
   parameter {
     name  = "maintenance_work_mem"
     value = "10000"
+	quote = false
   }
 `
 
@@ -310,6 +311,7 @@ resource "postgresql_role" "role" {
   parameter {
     name  = "maintenance_work_mem"
     value = "10000"
+	quote = false
   }
 `
 

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -45,7 +45,7 @@ resource "postgresql_role" "my_audited_role" {
   name     = "audited_role"
   login    = true
   password = "mypas"
-  
+
   parameter {
     name  = "pgaudit.log"
     value = "all"
@@ -144,6 +144,9 @@ configuration parameters.
 * `name` - (Required) Name of a configuration parameter.
 
 * `value` - (Required) Value to set for the configuration parameter.
+
+* `quote` - (Optional) Quote the value of the parameter as a literal.
+  Defaults value is `true`.
 
 ## Import Example
 


### PR DESCRIPTION
## Rationale

In the original PR I had removed `pq.QuoteLiteral` because it broke setting `search_path`, and specifying both string and integer values for other core parameters seemed to work fine without quotes. In the end, of course, I disabled setting `search_path` with a `parameter` block anyway due to conflicts with the discrete `search_path` argument.

Turns out when you set `pgaudit.log` (and maybe other custom parameters for extensions?) not quoting your literals _doesn't_ work. This didn't get sussed out in the acceptance tests because the acceptance tests can only use core parameters; there are no extensions installed.

Rather than swinging fully in the opposite direction, I decided to make whether quotes are used configurable. To that end, parameters now have an optional `quote` argument, which defaults to `true` because I think that's the most reasonable. Some extra care had to be taken in the read function to prevent weird diff problems, which I'll detail in the self-review.